### PR TITLE
Debug script to run sairy executable from workspace

### DIFF
--- a/SETUP_ENV.sh
+++ b/SETUP_ENV.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export SAIRY_PREFIX=./build/scheme:./share/sairy
-export DYLD_LIBRARY_PATH=../boost/lib:./build/scheme/lib
-

--- a/bin/sairy.in
+++ b/bin/sairy.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+SAIRY_PREFIX="@PROJECT_BINARY_DIR@/scheme":./share/sairy "@sairy_executable_path@" "$@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,6 +150,27 @@ target_link_libraries(sairy
   ${LibClang_LIBRARIES}
   ${Boost_LIBRARIES})
 
+set(sairy_app "${PROJECT_BINARY_DIR}/app")
+set_target_properties(sairy
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${sairy_app}")
+set_target_properties(sairy
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${sairy_app}")
+set_target_properties(sairy
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${sairy_app}")
+
+
+if(POLICY CMP0026)
+cmake_policy(PUSH)
+cmake_policy(SET CMP0026 OLD)
+endif()
+
+get_property(sairy_executable_path TARGET sairy PROPERTY LOCATION)
+configure_file("${PROJECT_SOURCE_DIR}/bin/sairy.in" "${PROJECT_SOURCE_DIR}/bin/sairy"
+               @ONLY)
+
+if(POLICY CMP0026)
+cmake_policy(POP)
+endif()
 
 #------------------------------------------------------------------------------
 add_subdirectory(test)


### PR DESCRIPTION
Ignore get_property LOCATION warning, until we find a reasonable way
to generate a starter_script with executable flags...
